### PR TITLE
adds use strict to make it work in node 4

### DIFF
--- a/flows/chatter.js
+++ b/flows/chatter.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const handleHowAreYou = 'chatter:handleHowAreYou'
 
 module.exports = (slackapp) => {

--- a/flows/hilo.js
+++ b/flows/hilo.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const handleHiLo = 'hilo:handle'
 
 module.exports = (slackapp) => {

--- a/flows/index.js
+++ b/flows/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = (slackapp) => {
   require('./whoisin')(slackapp)
   require('./hilo')(slackapp)

--- a/flows/reaction.js
+++ b/flows/reaction.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = (slackapp) => {
 
   slackapp.event('reaction_added', (msg) => {

--- a/flows/whoisin.js
+++ b/flows/whoisin.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const os = require('os')
 const times = require('times-loop')
 

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
+'use strict'
+
 const express = require('express')
-const slack = require('slack')
 const SlackApp = require('slackapp')
 const BeepBoopConvoStore = require('slackapp-convo-beepboop')
 if (!process.env.PORT) throw Error('PORT missing but required')
@@ -34,5 +35,5 @@ app.get('/', function (req, res) {
   res.send('Hello')
 })
 
-console.log("Listening on :" + process.env.PORT)
+console.log('Listening on :' + process.env.PORT)
 app.listen(process.env.PORT)


### PR DESCRIPTION
Adds `use strict` to avoid some `SyntaxErrors` that get thrown in node 4.

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

Pulled out unused `slack` require and couldn't help but fix 1 linting error standard was complaining about...
