### PR TITLE
removes 2 unused deps and bumps up deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.14.0",
-    "slack": "^7.5.6",
-    "slapp": "0.1.0",
-    "slapp-convo-beepboop": "0.2.0",
-    "times-loop": "^1.0.0"
+    "slapp": "^0.1.0",
+    "slapp-convo-beepboop": "^0.2.1"
   }
 }


### PR DESCRIPTION
Removes 2 unused deps from `package.json`
- `slack`
- `times-loop`

Bumps up `slapp-app-convo` module and updated version values to `^` to grab updates
