### PR TITLE
makes text lowercase for consistency and fixes typo

### DIFF
--- a/flows/whoisin.js
+++ b/flows/whoisin.js
@@ -77,7 +77,7 @@ module.exports = (slapp) => {
         },
         {
           name: 'unaccounted',
-          text: ':thinking_face: Hasn\'t anwered?',
+          text: ':thinking_face: hasn\'t answered?',
           type: 'button'
         }
       ]


### PR DESCRIPTION
Went with making the text lowercase for consistency and also fixed the `answered` typo

Fixes #6 
