### PR TITLE
Small format tweak to votes list

### DIFF
--- a/src/poll.js
+++ b/src/poll.js
@@ -254,7 +254,7 @@ class Poll {
       if (answer.people.length > 0) {
         msg
           .attachment()
-          .text(`*${answer.people.length}*  ${answer.text} » ${answer.people.join(',')}`)
+          .text(`*${answer.people.length}*  ${answer.text}  ⇢  _${answer.people.map((it) => `@${it}`).join(', ')}_`)
           .mrkdwnIn(['text'])
       }
     })

--- a/src/poll.js
+++ b/src/poll.js
@@ -254,7 +254,7 @@ class Poll {
       if (answer.people.length > 0) {
         msg
           .attachment()
-          .text(`*${answer.people.length}*  ${answer.text}  ⇢  _${answer.people.map((it) => `@${it}`).join(', ')}_`)
+          .text(`*${answer.people.length}*  ${answer.text}  ⇢  _${answer.people.map(it => `@${it}`).join(', ')}_`)
           .mrkdwnIn(['text'])
       }
     })


### PR DESCRIPTION
Adds spaces between names, `@` appended to names but without a mention, changed arrow formatting.
![screenshot 2017-01-10 08 51 02](https://cloud.githubusercontent.com/assets/30455/21812983/ed43d1f4-d711-11e6-95c7-8f3c921102b4.png)
